### PR TITLE
Add note about ODBC header when installing on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Easiest install is to use pip:
 
     pip install dbt-sqlserver
 
+On Ubuntu make sure you have the ODBC header files before installing
+    
+    sudo apt install unixodbc-dev
  
 ## Configure your profile
 Configure your dbt profile for using SQL Server authentication or Integrated Security:


### PR DESCRIPTION
I installed adapter in a Docker based on Ubuntu 18.04. Installation failed because of missing ODBC headers which pyodbc depends on. See:

https://github.com/mkleehammer/pyodbc/issues/441