### PR TITLE
Fixes #31. Bounded dbt core requirements for v0.15.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Passing all tests in [dbt-integration-tests](https://github.com/fishtown-analyti
 Only supports dbt 0.14 and newer!
 - For dbt 0.14.x use dbt-sqlserver 0.14.x
 - For dbt 0.15.x use dbt-sqlserver 0.15.x
+- dbt 0.16.x is unsupported
+- dbt 0.17.x is unsupported  - development in progress
 
 Easiest install is to use pip:
 
@@ -14,7 +16,7 @@ Easiest install is to use pip:
 On Ubuntu make sure you have the ODBC header files before installing
     
     sudo apt install unixodbc-dev
- 
+
 ## Configure your profile
 Configure your dbt profile for using SQL Server authentication or Integrated Security:
 ##### SQL Server authentication 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         ]
     },
     install_requires=[
-        'dbt-core>=0.15.0',
+        'dbt-core>=0.15.0,<0.16',
         'pyodbc>=4.0.27',
     ]
 )


### PR DESCRIPTION
Added a comment on Readme and bounded the import to prevent import of 0.17 and issue of incorrectly found duplicates [issue 2423](https://github.com/fishtown-analytics/dbt/issues/2423).

Tested by locally installing inside a venv and got dbt-core 0.15.3.

