### PR TITLE
fix pyodbc connection string for custom port

### DIFF
--- a/dbt/adapters/sqlserver/connections.py
+++ b/dbt/adapters/sqlserver/connections.py
@@ -87,8 +87,7 @@ class SQLServerConnectionManager(SQLConnectionManager):
         try:
             con_str = []
             con_str.append(f"DRIVER={{{credentials.driver}}}")
-            con_str.append(f"SERVER={credentials.host}")
-            con_str.append(f"PORT={credentials.port}")
+            con_str.append(f"SERVER={credentials.host},{credentials.port}")
             con_str.append(f"Database={credentials.database}")
 
             if not getattr(credentials, 'windows_login', False):


### PR DESCRIPTION
Hi.

The previous conn_str did not handle ports different from 1433. The pyodbc.connect receive custom port like `server=ip,port` instead of `server=ip;port=port`