### PR TITLE
hotfix for v.0.16 change (see dbt PR #2037)

### DIFF
--- a/dbt/include/sqlserver/macros/catalog.sql
+++ b/dbt/include/sqlserver/macros/catalog.sql
@@ -1,5 +1,5 @@
 
-{% macro sqlserver__get_catalog(information_schemas) -%}
+{% macro sqlserver__get_catalog(information_schema, schemas) -%}
 
   {%- call statement('catalog', fetch_result=True) -%}
 


### PR DESCRIPTION
Making the fix for a breaking change from `v0.16.0` per this [Slack thread](https://getdbt.slack.com/archives/CMRMDDQ9W/p1598363160003200), to match https://github.com/fishtown-analytics/dbt/pull/2037