### PR TITLE
added support for named instance

### DIFF
--- a/dbt/adapters/sqlserver/connections.py
+++ b/dbt/adapters/sqlserver/connections.py
@@ -87,7 +87,14 @@ class SQLServerConnectionManager(SQLConnectionManager):
         try:
             con_str = []
             con_str.append(f"DRIVER={{{credentials.driver}}}")
-            con_str.append(f"SERVER={credentials.host},{credentials.port}")
+            
+            if "\\" in credentials.host:
+                # if there is a backslash \ in the host name the host is a sql-server named instance
+                # in this case then port number has to be omitted
+                con_str.append(f"SERVER={credentials.host}")
+            else:
+                con_str.append(f"SERVER={credentials.host},{credentials.port}")
+
             con_str.append(f"Database={credentials.database}")
 
             if not getattr(credentials, 'windows_login', False):


### PR DESCRIPTION
Referring https://github.com/mikaelene/dbt-sqlserver/issues/50

If sql server host name contains a backslash - pointing at a named instance connection to server fails

This is because if a named instance is specified, the port number must be omitted. This is fixed by checking if the specified host name contains a "\" and in that case the port number is omitted




