### PR TITLE
Update dbt_project.yml

### DIFF
--- a/dbt/include/sqlserver/dbt_project.yml
+++ b/dbt/include/sqlserver/dbt_project.yml
@@ -2,4 +2,6 @@
 name: dbt_sqlserver
 version: 1.0
 
+config-version: 2
+
 macro-paths: ["macros"]


### PR DESCRIPTION
Remove deprecation warning from dbt v0.17 config file changes. Right now anything built with dbt-sqlserver will throw a warning:

```
* Deprecation Warning: dbt v0.17.0 introduces a new config format for the
  dbt_project.yml file. Support for the existing version 1 format will be removed
  in a future release of dbt. The following packages are currently configured with
  config version 1:
   - dbt_sqlserver

  For upgrading instructions, consult the documentation:
    https://docs.getdbt.com/docs/guides/migration-guide/upgrading-to-0-17-0
```

This causes anything that runs dbt with `--strict` or `--warn-error` (e.g. a CI pipeline on a dbt project) to fail. Since the only thing in that config is an additional macro path, all we need is a version flag to bring it in line with the new format.