### PR TITLE
Implement get_columns_in_query macro to fix snapshots with check_cols='all'

### DIFF
--- a/dbt/include/sqlserver/macros/adapters.sql
+++ b/dbt/include/sqlserver/macros/adapters.sql
@@ -2,6 +2,19 @@
   information_schema
 {%- endmacro %}
 
+
+{% macro sqlserver__get_columns_in_query(select_sql) %}
+    {% call statement('get_columns_in_query', fetch_result=True, auto_begin=False) -%}
+        select TOP 0 * from (
+            {{ select_sql }}
+        ) as __dbt_sbq
+        where 0 = 1
+    {% endcall %}
+
+    {{ return(load_result('get_columns_in_query').table.columns | map(attribute='name') | list) }}
+{% endmacro %}
+
+
 {% macro sqlserver__list_relations_without_caching(schema_relation) %}
   {% call statement('list_relations_without_caching', fetch_result=True) -%}
     select


### PR DESCRIPTION
Fix for snapshots failing if check_cols='all' is set in config, due to default implementation of get_columns_in_query not being valid MS SQL. 